### PR TITLE
129 infer safety issues when no regex safety issues are found

### DIFF
--- a/engine/Extract_Analyze/ReportExtracting.py
+++ b/engine/Extract_Analyze/ReportExtracting.py
@@ -187,6 +187,7 @@ class ReportExtractor:
         for regex in safety_issues_regexes:
             if len(safety_issue_matches) > 0 and regex.search(self.report_text):
                 print("Error: multiple regexes matched")
+                return None
 
             if len(safety_issue_matches) == 0 and regex.search(self.report_text):
                 safety_issue_matches.extend(regex.findall(self.report_text))

--- a/engine/Extract_Analyze/ReportExtracting.py
+++ b/engine/Extract_Analyze/ReportExtracting.py
@@ -235,12 +235,15 @@ Please just return the cleaned version of the text. Without starting with Safety
 {text}
         
 =Instructions=
+
+I want to know the safety issues which this investigation has found.
+
 Can your response please be in yaml format.
 
 - |
-    blablabla
+    bla bla bla
 - |
-    bla bla lba
+    bla bla bla bla
 
 There is no need to enclose the yaml in any tags.
 
@@ -271,7 +274,29 @@ You are going help me read a transport accident investigation report.
 
  I want you to please read the report and respond with the safety issues identified in the report.
 
-Please only respond with safety issues that are quite clear and important.
+Please only respond with safety issues that are quite clearly stated and/or implied.
+
+It should be noted that the number of safety issues in a report has a minimum of 1 an 0.25 quantile of 1, median of 2, 0.75 quantile of 3 and a maximum of 13. You should try make your answers match this distribution and on average a report will have only 2 safety issues.
+
+Remember the definitions give
+
+Safety factor - Any (non-trivial) events or conditions, which increases safety risk. If they occurred in the future, these would
+increase the likelihood of an occurrence, and/or the
+severity of any adverse consequences associated with the
+occurrence.
+
+Safety issue - A safety factor that:
+• can reasonably be regarded as having the
+potential to adversely affect the safety of future
+operations, and
+• is characteristic of an organisation, a system, or an
+operational environment at a specific point in time.
+Safety Issues are derived from safety factors classified
+either as Risk Controls or Organisational Influences.
+
+Safety theme - Indication of recurring circumstances or causes, either across transport modes or over time. A safety theme may
+cover a single safety issue, or two or more related safety
+issues.
             """,
             message(important_text),
             large_model=True,
@@ -280,8 +305,12 @@ Please only respond with safety issues that are quite clear and important.
         if response[:7] == '"""yaml' or response[:7] == '```yaml':
             response = response[7:-3]
         
-        
-        safety_issues = yaml.safe_load(response)
+        try:
+            safety_issues = yaml.safe_load(response)
+        except yaml.YAMLError as exc:
+            print(exc)
+            print("  Assuming that there are no safety issues in the report.")
+            return None
         
         return safety_issues
 

--- a/engine/Extract_Analyze/ReportExtracting.py
+++ b/engine/Extract_Analyze/ReportExtracting.py
@@ -99,7 +99,7 @@ class ReportExtractor:
         return pages_to_read
 
     def extract_section(self, section_str: str):
-        base_regex_template = lambda section: fr"(( {section}) {{1,3}}(?![\s\S]*^{section}))|((^{section}) {{1,3}})(?![\S\s()]{{1,100}}\.{{2,}})"
+        base_regex_template = lambda section: fr"(?<!\.{{3,}} {{0,4}}\d{{1,3}} ?\s)((( {section}) {{1,3}}(?![\s\S]*^{section}))|((^{section}) {{1,3}}))(?![\S\s()]{{1,100}}\.{{2,}})"
 
         split_section = section_str.split(".")
         section = split_section[0]

--- a/engine/Gather_Wrangle/PDFDownloader.py
+++ b/engine/Gather_Wrangle/PDFDownloader.py
@@ -67,11 +67,12 @@ class ReportDownloader:
         report_dir = os.path.join(self.output_dir, self.report_dir_template.replace(r"{{report_id}}", report_id))
 
         file_name = os.path.join(report_dir, self.file_name_template.replace(r"{{report_id}}", report_id))
-        response = requests.get(url)
 
         if not self.refresh and os.path.exists(file_name):
             print(f"  {file_name} already exists, skipping download")
             return True
+
+        response = requests.get(url)
 
         soup = BeautifulSoup(response.content, "html.parser")
 


### PR DESCRIPTION
The inferences of safety themes has been implemented

There are just a couple of things that need to be odne before we can merge this

- [ ] Confirm that the safety issues are correct when they are infrered. I believe a problem may be in the model distiguishing a safety factor from a safety issue.
- [ ] Handle the case where a report has no safety issues. This has been explicitly advised to not be possible however as mentioned in [#129](https://github.com/1jamesthompson1/TAIC-report-summary/issues/129#issuecomment-2016967402) it might not be the case.