### PR TITLE
Adding in paragraph extraction for all reports that dont have section extraction.

### DIFF
--- a/notebooks/text_extraction_from_all_agencies/#267.ipynb
+++ b/notebooks/text_extraction_from_all_agencies/#267.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# what\n",
+    "\n",
+    "This is going to be me doing a section extraction of the reports.\n",
+    "\n",
+    "For some of the rpeorts there will be regex section extra section of the paragraph numbers.\n",
+    "\n",
+    "However for many of the reports this is not possible so I will perform a more traditional document chunking technique. However I do need to have a unique ID for each section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import engine.extract.ReportExtracting as ReportExtracting\n",
+    "import shutil\n",
+    "import os\n",
+    "import re\n",
+    "import numpy as np\n",
+    "import importlib\n",
+    "from tqdm import tqdm\n",
+    "importlib.reload(ReportExtracting)\n",
+    "\n",
+    "tqdm.pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Current state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_text = pd.read_pickle(\n",
+    "    '../../output/parsed_reports.pkl'\n",
+    ")\n",
+    "report_text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extractor = ReportExtracting.ReportExtractingProcessor('../../output/parsed_reports.pkl')\n",
+    "extractor.extract_sections_from_text(15, 'report_section.pkl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_section = pd.read_pickle('report_section.pkl').merge(report_text, on='report_id')[['report_id', 'text', 'sections']].set_index('report_id')  \n",
+    "report_section['num_sections'] = report_section['sections'].map(lambda x: len(x))\n",
+    "report_section['has_sections'] = report_section['num_sections'] > 0\n",
+    "report_section['year'] = report_section.index.map(lambda x: int(x.split('_')[2]))\n",
+    "report_section['agency'] = report_section.index.map(lambda x: x.split('_')[0])\n",
+    "report_section['avg_section_length'] = report_section['sections'].map(lambda x: np.mean(x['section_text'].map(len)) if )\n",
+    "report_section"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reports without matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_sections = report_section[report_section['has_sections'] == False]\n",
+    "display(missing_sections['year'].describe())\n",
+    "display(missing_sections['agency'].value_counts())\n",
+    "missing_sections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most of the reports are not being matched by the current report section extractor.\n",
+    "\n",
+    "I will need to confirm that there are not report that are being missed by the report extractor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_sections.loc['ATSB_a_2000_072']['paragraphs']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Manually looking at all of the report pdfs and see if theyt exist\n",
+    "if os.path.exists('reports_to_look_at'):\n",
+    "    shutil.rmtree('reports_to_look_at')\n",
+    "os.mkdir('reports_to_look_at')\n",
+    "for report in missing_sections.sample(frac=0.01, random_state=42).index:\n",
+    "    shutil.copyfile(f'../../output/report_pdfs/{report}.pdf', f'reports_to_look_at/{report}.pdf') \n",
+    "    with open(f'reports_to_look_at/{report}.txt', 'w') as f:\n",
+    "        f.write(missing_sections.loc[report]['text'])\n",
+    "    with open(f'reports_to_look_at/{report}_sections.txt', 'w') as f:\n",
+    "        f.write('\\n\\n'.join([f'{paragraph_name}\\n{paragraph}' for _, paragraph_name, paragraph in missing_sections.loc[report]['paragraphs'].itertuples()]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Looking at current taic sections\n",
+    "\n",
+    "I want to know how  big the sections are becuase maybe I could just split up into pages. Or try to do paragraphs. However I know that paragraphsare going to be harder because random spaces are always added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taic_sections = report_section[(report_section['has_sections'] == True) & (report_section['agency'] == 'TAIC')]\n",
+    "display(taic_sections['year'].hist())\n",
+    "display(taic_sections['agency'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.concat(taic_sections['sections'].tolist())['section_text'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "other_sections = report_section[(report_section['num_sections'] > 4)  & (report_section['agency'] != 'TAIC')]\n",
+    "display(other_sections['year'].hist())\n",
+    "display(other_sections['agency'].value_counts())\n",
+    "pd.concat(other_sections['sections'].tolist())['section_text'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"TAIC sections average section length\")\n",
+    "display(taic_sections['sections'].map(lambda x: x['section_text'].map(len).mean()).describe())\n",
+    "print(\"Taic sections average number of sections\")\n",
+    "taic_sections['sections'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Other sections average section length\")\n",
+    "display(other_sections['sections'].map(lambda x: x['section_text'].map(len).mean()).describe())\n",
+    "print(\"Other sections aaverage number of sections\")\n",
+    "other_sections['sections'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def inspect(dir, df):\n",
+    "    if os.path.exists(dir):\n",
+    "        shutil.rmtree(dir)\n",
+    "    os.mkdir(dir)\n",
+    "    for report in df.index:\n",
+    "        shutil.copyfile(f'../../output/report_pdfs/{report}.pdf', f'{dir}/{report}.pdf') \n",
+    "        with open(f'{dir}/{report}.txt', 'w') as f:\n",
+    "            f.write(df.loc[report]['text'])\n",
+    "        with open(f'{dir}/{report}_sections.txt', 'w') as f:\n",
+    "            f.write('\\n\\n'.join([f'{section}\\n{section_text}' for _, section, section_text, _ in df.loc[report]['sections'].itertuples()]))\n",
+    "\n",
+    "\n",
+    "inspect('other_section', other_sections.sample(10, random_state=42))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "THe autowork of the section extractors has not worked on the other agencies reports. This is problematic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Looking at using pages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_pages(text):\n",
+    "    page_matches = list(re.finditer(r'<< Page (\\d+|[xvi]+) >>', text))\n",
+    "\n",
+    "    pages = []\n",
+    "    for page_match in range(len(page_matches)-1):\n",
+    "\n",
+    "        page = page_matches[page_match].group(1)\n",
+    "\n",
+    "        pages.append({\n",
+    "            \"page\": page,\n",
+    "            \"text\": text[page_matches[page_match].start():page_matches[page_match+1].start()],\n",
+    "        })\n",
+    "\n",
+    "    return pd.DataFrame(pages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_sections['pages'] = missing_sections['text'].map(extract_pages)\n",
+    "missing_sections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.concat(missing_sections['pages'].tolist())['text'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The problem here is that they are about 2 and half times longer so they are not splitting it up very well."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Looking at paragraph splitting\n",
+    "\n",
+    "I am not sure if this will work but will have alook at it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_into_paragraphs(text):\n",
+    "    raw_splits = [paragraph.strip() for paragraph in re.split(r'\\n *\\n', text) if len(paragraph.strip()) > 0]\n",
+    "\n",
+    "    splits_df = pd.DataFrame(raw_splits, columns=['paragraph'])\n",
+    "    \n",
+    "    splits_df['page'] = splits_df['paragraph'].map(lambda x: re.match(r'<< Page (\\d+|[xvi]+) >>', x).group(1) if re.match(r'<< Page (\\d+|[xvi]+) >>', x ) else None)\n",
+    "    splits_df.ffill(inplace=True)\n",
+    "    splits_df.replace({np.nan: '0', None: '0'}, inplace=True)\n",
+    "    splits_df['paragraph_num'] = splits_df.groupby(['page']).cumcount()\n",
+    "    splits_df['paragraph_name'] = 'p' + splits_df['page'] + \".\" + splits_df['paragraph_num'].astype(str)\n",
+    "\n",
+    "    splits_df = splits_df[splits_df['paragraph'].map(lambda x: len(re.sub(r'<< Page (\\d+|[xvi]+) >>', '', x).strip()))>8]\n",
+    "\n",
+    "    return splits_df[['paragraph_name', 'paragraph']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_sections['paragraphs'] = missing_sections['text'].map(split_into_paragraphs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.concat(missing_sections['paragraphs'].tolist())['paragraph'].map(len).describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This seems to be working alright and is of reasonable length."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This works well enough with a good enough size. I can come back to it if it seems important at a later date.

About 700 reports use the section wtih numbers. The rest use the paragraph splitting with a mean size of about 2500 chracters.